### PR TITLE
docs: fix typo

### DIFF
--- a/versioned_docs/version-V2/guides/identities.md
+++ b/versioned_docs/version-V2/guides/identities.md
@@ -42,7 +42,7 @@ const nullifier = identity.getNullifier()
 
 ### Create deterministic identities
 
-If you pass a message as a parameter, trapdoor and nullifier will be generated from the SHA256 hash of the message. The message must clearly be kept secret in turn, since anyone who owns the message can recreate the same identity. The massage can be a password or a message signed with a private key.
+If you pass a message as a parameter, trapdoor and nullifier will be generated from the SHA256 hash of the message. The message must clearly be kept secret in turn, since anyone who owns the message can recreate the same identity. The message can be a password or a message signed with a private key.
 
 ```ts
 const identity = new Identity("secret-message")


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Description

In the `Create deterministic identities` paragraph of `identities.md` fix typo `massage`  into `message`.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
