### PR TITLE
Replace Telegram chat links with the new Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://t.me/joinchat/B-PQx1U3GtAh--Z4Fwo56A">
+        <a href="https://discord.gg/6mSdGHnstH">
             🗣️ Chat &amp; Support
         </a>
     </h4>

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -41,8 +41,8 @@ function Footer() {
                         </div>
                         <div>
                             <h3>Connect</h3>
-                            <Link href="https://t.me/joinchat/B-PQx1U3GtAh--Z4Fwo56A" target="_blank">
-                                Telegram
+                            <Link href="https://discord.gg/6mSdGHnstH" target="_blank">
+                                Discord
                             </Link>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Description

Replace all Telegram chat links with the invitation link of our new Discord server.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#28 
