### PR TITLE
fix: typo and broken link in proof guide

### DIFF
--- a/versioned_docs/version-V2/guides/proofs.md
+++ b/versioned_docs/version-V2/guides/proofs.md
@@ -87,7 +87,7 @@ To verify Semaphore proofs in your contract, import `SemaphoreCore` and pass the
 
 Remember to save the `nullifierHash` on-chain to avoid double-signaling.
 
-Alternatively, you can use an already deployed [`Semaphore`](https://github.com/semaphore-protocol/semaphore/tree/v2.6.1/packages/contracts/Semaphore.sol) contract and use its `verifiyProof` external function.
+Alternatively, you can use an already deployed [`Semaphore`](https://github.com/semaphore-protocol/semaphore/blob/v2.6.1/packages/contracts/contracts/Semaphore.sol) contract and use its `verifyProof` external function.
 
 ### Generate a Solidity-compatible proof
 


### PR DESCRIPTION
Fixes a small typo and a broken link to the `Semaphore.sol` contract in https://semaphore.appliedzkp.org/docs/guides/proofs#verify-a-proof-on-chain

<img width="985" alt="Screenshot 2023-01-09 at 13 43 14" src="https://user-images.githubusercontent.com/7974813/211253358-601804a8-f29d-4175-99e2-335519ef6963.png">
