### PR TITLE
Fixing Semaphore.sol github link

### DIFF
--- a/versioned_docs/version-V3/technical-reference/contracts.md
+++ b/versioned_docs/version-V3/technical-reference/contracts.md
@@ -40,7 +40,7 @@ More extensions will be added in the future.
 
 ## Semaphore.sol
 
-[`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/Semaphore.sol) is based on the base contracts. It integrates them and additionally provides:
+[`Semaphore.sol`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol) is based on the base contracts. It integrates them and additionally provides:
 
 -   a system to allow only admins (i.e. Ethereum accounts or smart contracts) to manage groups;
 -   a mechanism to save the [nullifier hashes](/docs/technical-reference/circuits#nullifier-hash) of each group and prevent double-signaling;


### PR DESCRIPTION
Just adding the correct link to the github page for Semaphore.sol, the previous one is broken.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
