### PR TITLE
docs: Include pnpm as a package manager in the docs

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/fetching-data.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/fetching-data.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem"
 
 # Semaphore data
 
-Para obtener datos on-chain del contrato [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol), puedes usar la librería [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos on-chain del contrato [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol), puedes usar la librería [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 Hay dos formas para hacer esto, usando [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) o [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts). La clase `SemaphoreSubgraph` usa el [subgrafo de Semaphore](https://github.com/semaphore-protocol/subgraph), el cual usa [The Graph Protocol](https://thegraph.com/) detrás del telón, y la clase `SemaphoreEthers` usa [Ethers](https://github.com/ethers-io/ethers.js/).
 
@@ -23,6 +23,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -38,11 +39,18 @@ yarn add @semaphore-protocol/data
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/data
+```
+
+</TabItem>
 </Tabs>
 
 ## Obtener datos usando SemaphoreSubgraph
 
-Para obtener datos usando el subgrafo de Semaphore puedes usar la clase [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos usando el subgrafo de Semaphore puedes usar la clase [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 ```typescript
 import { SemaphoreSubgraph } from "@semaphore-protocol/data"
@@ -109,7 +117,7 @@ const group = new Group(groupId, 20, members)
 
 ## Obtener datos usando SemaphoreEthers
 
-Para obtener datos usando Ethers puedes usar la clase [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data). 
+Para obtener datos usando Ethers puedes usar la clase [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) del paquete [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data).
 
 ```typescript
 import { SemaphoreEthers } from "@semaphore-protocol/data"

--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/groups.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/groups.mdx
@@ -39,7 +39,7 @@ Utilice la clase `Group` de la librería [`@semaphore-protocol/group`](https://g
 
 -   `Group id`: un identificar único para el grupo;
 -   `Tree depth`: (_default `20`_) el número máximo de usuarios que puede contener un grupo, el valor por defecto es 20 (`max size = 2 ^ tree depth`).
--   `Members`: (_default `[]`_) la lista de miembros para inicializar el grupo. 
+-   `Members`: (_default `[]`_) la lista de miembros para inicializar el grupo.
 
 #### Instalar librería:
 
@@ -49,6 +49,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -61,6 +62,13 @@ npm install @semaphore-protocol/group
 
 ```bash
 yarn add @semaphore-protocol/group
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/group
 ```
 
 </TabItem>

--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/identities.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/identities.mdx
@@ -32,6 +32,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -44,6 +45,13 @@ npm install @semaphore-protocol/identity
 
 ```bash
 yarn add @semaphore-protocol/identity
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/identity
 ```
 
 </TabItem>

--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/proofs.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/guides/proofs.mdx
@@ -38,6 +38,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,13 @@ npm install @semaphore-protocol/proof
 
 ```bash
 yarn add @semaphore-protocol/proof
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/proof
 ```
 
 </TabItem>

--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/quick-setup.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/quick-setup.mdx
@@ -36,6 +36,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,14 @@ npm i
 ```bash
 cd my-app
 yarn
+```
+</TabItem>
+
+<TabItem value="pnpm">
+
+```bash
+cd my-app
+pnpm install
 ```
 
 </TabItem>
@@ -112,6 +121,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -127,6 +137,13 @@ yarn compile
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm compile
+```
+
+</TabItem>
 </Tabs>
 
 ### Pruebe los contratos
@@ -139,6 +156,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -154,6 +172,13 @@ yarn test
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test
+```
+
+</TabItem>
 </Tabs>
 
 Genere un reporte de la prueba de cobertura:
@@ -164,6 +189,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -179,6 +205,13 @@ yarn test:coverage
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:coverage
+```
+
+</TabItem>
 </Tabs>
 
 O un reporte de la prueba de gas:
@@ -189,6 +222,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -201,6 +235,13 @@ npm run test:report-gas
 
 ```bash
 yarn test:report-gas
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:report-gas
 ```
 
 </TabItem>
@@ -226,6 +267,7 @@ En la carpeta raíz del proyecto:
     values={[
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'}
     ]}>
     <TabItem value="npm">
 
@@ -238,6 +280,13 @@ En la carpeta raíz del proyecto:
 
     ```bash
     yarn deploy --semaphore <semaphore-address> --group <group-id> --network goerli
+    ```
+
+    </TabItem>
+    <TabItem value="pnpm">
+
+    ```bash
+    pnpm deploy --semaphore <semaphore-address> --group <group-id> --network goerli
     ```
 
     </TabItem>
@@ -261,6 +310,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -273,6 +323,13 @@ npm run dev
 
 ```bash
 yarn dev
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm dev
 ```
 
 </TabItem>

--- a/i18n/es/docusaurus-plugin-content-docs/version-V3/troubleshooting.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/version-V3/troubleshooting.mdx
@@ -75,6 +75,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -90,6 +91,13 @@ yarn add @esbuild-plugins/node-globals-polyfill
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-globals-polyfill
+```
+
+</TabItem>
 </Tabs>
 
 <Tabs
@@ -98,6 +106,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -110,6 +119,13 @@ npm install @esbuild-plugins/node-modules-polyfill
 
 ```bash
 yarn add @esbuild-plugins/node-modules-polyfill
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-modules-polyfill
 ```
 
 </TabItem>

--- a/versioned_docs/version-V3/guides/fetching-data.mdx
+++ b/versioned_docs/version-V3/guides/fetching-data.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem"
 
 # Semaphore data
 
-To fetch on-chain data from the [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol) contract, you can use the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) library. 
+To fetch on-chain data from the [Semaphore.sol](https://github.com/semaphore-protocol/semaphore/blob/main/packages/contracts/contracts/Semaphore.sol) contract, you can use the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) library.
 
 There are two ways to do this, using [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) or [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts). The `SemaphoreSubgraph` class uses the [Semaphore subgraph](https://github.com/semaphore-protocol/subgraph), which uses [The Graph Protocol](https://thegraph.com/) under the hood, and the `SemaphoreEthers` class uses [Ethers](https://github.com/ethers-io/ethers.js/).
 
@@ -23,6 +23,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -38,11 +39,18 @@ yarn add @semaphore-protocol/data
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/data
+```
+
+</TabItem>
 </Tabs>
 
 ## Fetch data using SemaphoreSubgraph
 
-To fetch data using the Semaphore subgraph you can use the [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package. 
+To fetch data using the Semaphore subgraph you can use the [`SemaphoreSubgraph`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/subgraph.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package.
 
 ```typescript
 import { SemaphoreSubgraph } from "@semaphore-protocol/data"
@@ -109,7 +117,7 @@ const group = new Group(groupId, 20, members)
 
 ## Fetch data using SemaphoreEthers
 
-To fetch data using Ethers you can use the [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package. 
+To fetch data using Ethers you can use the [`SemaphoreEthers`](https://github.com/semaphore-protocol/semaphore/blob/main/packages/data/src/ethers.ts) class from the [@semaphore-protocol/data](https://github.com/semaphore-protocol/semaphore/tree/main/packages/data) package.
 
 ```typescript
 import { SemaphoreEthers } from "@semaphore-protocol/data"

--- a/versioned_docs/version-V3/guides/groups.mdx
+++ b/versioned_docs/version-V3/guides/groups.mdx
@@ -39,7 +39,7 @@ Use the [`@semaphore-protocol/group`](https://github.com/semaphore-protocol/sema
 
 -   `Group id`: a unique identifier for the group;
 -   `Tree depth`: (_default `20`_) the maximum number of members a group can contain (`max size = 2 ^ tree depth`).
--   `Members`: (_default `[]`_) the list of members to initialize the group. 
+-   `Members`: (_default `[]`_) the list of members to initialize the group.
 
 #### Install library:
 
@@ -49,6 +49,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -61,6 +62,13 @@ npm install @semaphore-protocol/group
 
 ```bash
 yarn add @semaphore-protocol/group
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/group
 ```
 
 </TabItem>

--- a/versioned_docs/version-V3/guides/identities.mdx
+++ b/versioned_docs/version-V3/guides/identities.mdx
@@ -32,6 +32,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -44,6 +45,13 @@ npm install @semaphore-protocol/identity
 
 ```bash
 yarn add @semaphore-protocol/identity
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/identity
 ```
 
 </TabItem>

--- a/versioned_docs/version-V3/guides/proofs.mdx
+++ b/versioned_docs/version-V3/guides/proofs.mdx
@@ -38,6 +38,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,13 @@ npm install @semaphore-protocol/proof
 
 ```bash
 yarn add @semaphore-protocol/proof
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @semaphore-protocol/proof
 ```
 
 </TabItem>

--- a/versioned_docs/version-V3/quick-setup.mdx
+++ b/versioned_docs/version-V3/quick-setup.mdx
@@ -36,6 +36,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -50,6 +51,14 @@ npm i
 ```bash
 cd my-app
 yarn
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+cd my-app
+pnpm install
 ```
 
 </TabItem>
@@ -92,7 +101,7 @@ my-app
 └── tsconfig.json
 ```
 
-The `Feedback.sol` contract creates a Semaphore group, allows users to join that group with their Semaphore identity, and finally allows group members to send an anonymous feedback. 
+The `Feedback.sol` contract creates a Semaphore group, allows users to join that group with their Semaphore identity, and finally allows group members to send an anonymous feedback.
 
 ## Usage
 
@@ -112,6 +121,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -127,6 +137,13 @@ yarn compile
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm compile
+```
+
+</TabItem>
 </Tabs>
 
 ### Test contracts
@@ -139,6 +156,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -154,6 +172,13 @@ yarn test
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test
+```
+
+</TabItem>
 </Tabs>
 
 Generate a test coverage report:
@@ -164,6 +189,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -179,6 +205,13 @@ yarn test:coverage
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:coverage
+```
+
+</TabItem>
 </Tabs>
 
 Or a test gas report:
@@ -189,6 +222,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -201,6 +235,13 @@ npm run test:report-gas
 
 ```bash
 yarn test:report-gas
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm test:report-gas
 ```
 
 </TabItem>
@@ -226,6 +267,7 @@ In the project root folder:
     values={[
     {label: 'npm', value: 'npm'},
     {label: 'Yarn', value: 'yarn'},
+    {label: 'pnpm', value: 'pnpm'}
     ]}>
     <TabItem value="npm">
 
@@ -238,6 +280,13 @@ In the project root folder:
 
     ```bash
     yarn deploy --semaphore <semaphore-address> --group <group-id> --network arbitrum-goerli
+    ```
+
+    </TabItem>
+    <TabItem value="pnpm">
+
+    ```bash
+    pnpm deploy --semaphore <semaphore-address> --group <group-id> --network arbitrum-goerli
     ```
 
     </TabItem>
@@ -261,6 +310,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -273,6 +323,13 @@ npm run dev
 
 ```bash
 yarn dev
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm dev
 ```
 
 </TabItem>

--- a/versioned_docs/version-V3/troubleshooting.mdx
+++ b/versioned_docs/version-V3/troubleshooting.mdx
@@ -75,6 +75,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -90,6 +91,13 @@ yarn add @esbuild-plugins/node-globals-polyfill
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-globals-polyfill
+```
+
+</TabItem>
 </Tabs>
 
 <Tabs
@@ -98,6 +106,7 @@ groupId="package-managers"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'Yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'}
 ]}>
 <TabItem value="npm">
 
@@ -110,6 +119,13 @@ npm install @esbuild-plugins/node-modules-polyfill
 
 ```bash
 yarn add @esbuild-plugins/node-modules-polyfill
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add @esbuild-plugins/node-modules-polyfill
 ```
 
 </TabItem>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Description

In all the places where code blocks appear to use yarn or npm:
- Added a new label,  `{label: 'pnpm', value: 'pnpm'}`, 
- Added a new TabItem. For eg:
````
<TabItem value="pnpm">

```bash
pnpm add @semaphore-protocol/identity
```
</TabItem>
````

## Related Issue
https://github.com/semaphore-protocol/website/issues/109

