### PR TITLE
docs(guides): change localhost to 127.0.0.1 to avoid error

### DIFF
--- a/versioned_docs/version-V3/guides/fetching-data.mdx
+++ b/versioned_docs/version-V3/guides/fetching-data.mdx
@@ -131,7 +131,7 @@ const semaphoreEthers = new SemaphoreEthers("homestead", {
 })
 
 // or:
-const semaphoreEthers = new SemaphoreEthers("http://localhost:8545", {
+const semaphoreEthers = new SemaphoreEthers("http://127.0.0.1:8545", {
     address: "semaphore-address"
 })
 ```


### PR DESCRIPTION
## Description
Using `localhost` on linux in the `SemaphoreEthers` constructor causes an error.

Changing it to `127.0.0.1` would make it work everywhere.

## Related Issue
https://github.com/semaphore-protocol/semaphore/issues/469
